### PR TITLE
Composer: suggest symfony/yaml

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
 	},
 	"suggest": {
 		"symfony/locale": "Locale component provides fallback code to handle cases when the intl extension is missing.",
-		"kdyby/console": "If you wanna use extract command and much others, install also console."
+		"kdyby/console": "If you wanna use extract command and much others, install also console.",
+		"symfony/yaml": "If you wanna store translations in YAML format (supports multiline strings)."
 	},
 	"require-dev": {
 		"nette/tester": "@dev",


### PR DESCRIPTION
Until NEON adds support for it, YAML is best alternative format that can store multiline strings. But even when support arrives, I think that suggestion should be kept as Composer doesn't show suggest of not directly required packages.
