### PR TITLE
Missing whitelist option in the documentation

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -80,6 +80,7 @@ To change the default language, place this in your `app/config/config.neon`
 ```yml
 translation:
 	default: cs
+	whitelist: [cs, en, de] #....
 	fallback: [cs_CZ, cs]
 ```
 


### PR DESCRIPTION
How this could be missing in the docs? OMG! :)
I've spent few hours before I found why I couldn't load another language files
