### PR TITLE
Extension: fixed compatibility with Nette v2.2

### DIFF
--- a/src/Kdyby/Translation/DI/TranslationExtension.php
+++ b/src/Kdyby/Translation/DI/TranslationExtension.php
@@ -143,7 +143,7 @@ class TranslationExtension extends Nette\DI\CompilerExtension
 			$this->loadConsole($config);
 		}
 
-		$builder->getDefinition('nette.latte')
+		$builder->getDefinition('nette.latteFactory')
 			->addSetup('Kdyby\Translation\Latte\TranslateMacros::install(?->getCompiler())', array('@self'))
 			->addSetup('addFilter', array('translate', array($this->prefix('@helpers'), 'translate')))
 			->addSetup('addFilter', array('getTranslator', array($this->prefix('@helpers'), 'getTranslator')));


### PR DESCRIPTION
Service `nette.latte` was renamed to `nette.latteFactory`.
See https://github.com/nette/nette/commit/76a764393133dc6c4b2c05fc9be07522838996d8
