### PR TITLE
Removed semicolon

### DIFF
--- a/src/Kdyby/Translation/DI/TranslationExtension.php
+++ b/src/Kdyby/Translation/DI/TranslationExtension.php
@@ -390,7 +390,7 @@ class TranslationExtension extends Nette\DI\CompilerExtension
 	public function afterCompile(Code\ClassType $class)
 	{
 		$initialize = $class->methods['initialize'];
-		$initialize->addBody('Kdyby\Translation\Diagnostics\Panel::registerBluescreen();');
+		$initialize->addBody('Kdyby\Translation\Diagnostics\Panel::registerBluescreen()');
 	}
 
 


### PR DESCRIPTION
Nette adds it automatically so it is duplicate.
