### PR TITLE
Fixed bug with default value after shifting parameters in translate function

### DIFF
--- a/src/Kdyby/Translation/Translator.php
+++ b/src/Kdyby/Translation/Translator.php
@@ -115,6 +115,8 @@ class Translator extends BaseTranslator implements ITranslator
 		if (is_array($count)) {
 			$locale = $domain;
 			$domain = $parameters;
+			if ($domain === array())
+				$domain = NULL;
 			$parameters = $count;
 			$count = NULL;
 		}


### PR DESCRIPTION
After last commit it stopped working. In translate function, when $count parameter was ommited and other paramterers shifted, when domain wasn't set, it passed it wrong default value, array() instead of NULL which resulted in some Exception only god knows where... This helped and I think all other parameters are okay.
