### PR TITLE
Fix Tracy message Class is deprecated

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -185,7 +185,10 @@ protected function createTemplate($class = NULL)
 {
 	$template = parent::createTemplate($class);
 	$template->registerHelperLoader(callback($this->translator->createTemplateHelpers(), 'loader'));
-
+	/**
+	* If you are using nette >= 2.2.x helper must register as follows:
+	* $template->getLatte()->addFilter(NULL, array($this->translator->createTemplateHelpers, 'loader'));
+	*/
 	return $template;
 }
 ```


### PR DESCRIPTION
How fix tracy messages: Nette\Bridges\ApplicationLatte\Template::registerHelperLoader() is deprecated, use dynamic getLatte()->addFilter() if using Nette >= 2.2.x
