### PR TITLE
Translator: replace parameters even on untranslated messages

### DIFF
--- a/src/Kdyby/Translation/Translator.php
+++ b/src/Kdyby/Translation/Translator.php
@@ -165,7 +165,7 @@ class Translator extends BaseTranslator implements ITranslator
 			if ($this->panel !== NULL) {
 				$this->panel->markUntranslated($message);
 			}
-			$result = $message;
+			$result = strtr($message, $parameters);
 		}
 
 		return $result;
@@ -203,7 +203,7 @@ class Translator extends BaseTranslator implements ITranslator
 			if ($this->panel !== NULL) {
 				$this->panel->markUntranslated($message);
 			}
-			$result = $message;
+			$result = strtr($message, $parameters);
 		}
 
 		return $result;


### PR DESCRIPTION
looks much better when you have no translations yet and don't use message identifiers
