### PR TITLE
Better debug information for Neon errors.

### DIFF
--- a/src/Kdyby/Translation/Loader/NeonFileLoader.php
+++ b/src/Kdyby/Translation/Loader/NeonFileLoader.php
@@ -49,10 +49,10 @@ class NeonFileLoader extends ArrayLoader implements LoaderInterface
             $messages = Neon\Neon::decode(file_get_contents($resource));
 
         } catch (Nette\Utils\NeonException $e) {
-            throw new InvalidResourceException('Error parsing Neon.', 0, $e);
+            throw new InvalidResourceException(sprintf("Error parsing Neon: %s", $e->getMessage()), 0, $e);
 
         } catch (Nette\Neon\Exception $e) {
-            throw new InvalidResourceException('Error parsing Neon.', 0, $e);
+            throw new InvalidResourceException(sprintf("Error parsing Neon: %s", $e->getMessage()), 0, $e);
         }
 
         if (empty($messages)) {


### PR DESCRIPTION
Easiest search for error in Nette\Debugger. 