### PR TITLE
Make nette/application dependency optional

### DIFF
--- a/src/Kdyby/Translation/DI/TranslationExtension.php
+++ b/src/Kdyby/Translation/DI/TranslationExtension.php
@@ -266,13 +266,15 @@ class TranslationExtension extends Nette\DI\CompilerExtension
 		}
 
 		$applicationService = $builder->getByType('Nette\Application\Application') ?: 'application';
-		$builder->getDefinition($applicationService)
-			->addSetup('$service->onRequest[] = ?', array(array($this->prefix('@userLocaleResolver.param'), 'onRequest')));
-
-		if ($config['debugger'] && interface_exists('Tracy\IBarPanel')) {
+		if ($builder->hasDefinition($applicationService)) {
 			$builder->getDefinition($applicationService)
-				->addSetup('$self = $this; $service->onStartup[] = function () use ($self) { $self->getService(?); }', array($this->prefix('default')))
-				->addSetup('$service->onRequest[] = ?', array(array($this->prefix('@panel'), 'onRequest')));
+				->addSetup('$service->onRequest[] = ?', array(array($this->prefix('@userLocaleResolver.param'), 'onRequest')));
+
+			if ($config['debugger'] && interface_exists('Tracy\IBarPanel')) {
+				$builder->getDefinition($applicationService)
+					->addSetup('$self = $this; $service->onStartup[] = function () use ($self) { $self->getService(?); }', array($this->prefix('default')))
+					->addSetup('$service->onRequest[] = ?', array(array($this->prefix('@panel'), 'onRequest')));
+			}
 		}
 
 		Kdyby\Translation\Diagnostics\Panel::registerBluescreen();


### PR DESCRIPTION
It is not required in composer.json so the extension should not require it either in my opinion.