### PR TITLE
Faster compiling of extension

### DIFF
--- a/src/Kdyby/Translation/DI/TranslationExtension.php
+++ b/src/Kdyby/Translation/DI/TranslationExtension.php
@@ -62,6 +62,7 @@ class TranslationExtension extends Nette\DI\CompilerExtension
 			self::RESOLVER_REQUEST => TRUE,
 			self::RESOLVER_HEADER => TRUE,
 		),
+		'loaders' => array()
 	);
 
 	/**
@@ -143,7 +144,8 @@ class TranslationExtension extends Nette\DI\CompilerExtension
 			->setClass('Kdyby\Translation\TranslationLoader')
 			->setInject(FALSE);
 
-		$this->loadLoaders();
+		$loaders = $this->loadFromFile(__DIR__ . '/config/loaders.neon');
+		$this->loadLoaders($loaders, $config['loaders'] ? : array_keys($loaders));
 
 		if ($this->isRegisteredConsoleExtension()) {
 			$this->loadConsole($config);
@@ -225,11 +227,14 @@ class TranslationExtension extends Nette\DI\CompilerExtension
 
 
 
-	protected function loadLoaders()
+	protected function loadLoaders(array $loaders, array $allowed)
 	{
 		$builder = $this->getContainerBuilder();
 
-		foreach ($this->loadFromFile(__DIR__ . '/config/loaders.neon') as $format => $class) {
+		foreach ($loaders as $format => $class) {
+			if (array_search($format, $allowed) === FALSE) {
+				continue;
+			}
 			$builder->addDefinition($this->prefix('loader.' . $format))
 				->setClass($class)
 				->addTag(self::TAG_LOADER, $format);

--- a/tests/KdybyTests/Translation/Extension.phpt
+++ b/tests/KdybyTests/Translation/Extension.phpt
@@ -57,6 +57,24 @@ class ExtensionTest extends TestCase
 
 
 
+	public function testLoaders()
+	{
+		$sl = $this->createContainer('loaders.custom');
+
+		/** @var Kdyby\Translation\TranslationLoader $loader */
+		$loader = $sl->getService('translation.loader');
+
+		$loaders = $loader->getLoaders();
+		Assert::count(2, $loaders);
+		Assert::true(array_key_exists('php', $loaders));
+		Assert::true(array_key_exists('neon', $loaders));
+		Assert::false(array_key_exists('po', $loaders));
+		Assert::false(array_key_exists('dat', $loaders));
+		Assert::false(array_key_exists('csv', $loaders));
+	}
+
+
+
 	public function testLogging()
 	{
 		$sl = $this->createContainer('logging');

--- a/tests/KdybyTests/Translation/config/loaders.custom.neon
+++ b/tests/KdybyTests/Translation/config/loaders.custom.neon
@@ -1,0 +1,2 @@
+translation:
+	loaders: [php, neon]


### PR DESCRIPTION
When I using only one loader, other loaders unnecessarily looking for resources.

Solution:
```neon
translation:
    loaders: [neon]
```

Enables only neon loader => compiling is ~10x faster than before.

Statistics:
**All loaders**: ~ 2690 ms
**One loader**: ~ 262 ms