### PR TITLE
TranslationExtension: fixed invalid setup of custom latte factory

### DIFF
--- a/src/Kdyby/Translation/DI/TranslationExtension.php
+++ b/src/Kdyby/Translation/DI/TranslationExtension.php
@@ -270,8 +270,12 @@ class TranslationExtension extends Nette\DI\CompilerExtension
 				->addSetup('addFilter', ['getTranslator', [$this->prefix('@helpers'), 'getTranslator']]);
 		};
 
-		$latteFactoryService = $builder->getByType('Nette\Bridges\ApplicationLatte\ILatteFactory') ?: 'nette.latteFactory';
-		if ($builder->hasDefinition($latteFactoryService)) {
+		$latteFactoryService = $builder->getByType('Nette\Bridges\ApplicationLatte\ILatteFactory');
+		if (!$latteFactoryService || $builder->getDefinition($latteFactoryService)->getClass() !== 'Latte\Engine') {
+			$latteFactoryService = 'nette.latteFactory';
+		}
+
+		if ($builder->hasDefinition($latteFactoryService) && $builder->getDefinition($latteFactoryService)->getClass() === 'Latte\Engine') {
 			$registerToLatte($builder->getDefinition($latteFactoryService));
 		}
 


### PR DESCRIPTION
When application uses custom ILatteFactory implementation you can't just call addFilter on it because it is not Latte\Engine instance.