### PR TITLE
Update tests/extractor-files/HomepagePresenter.php to Nette 2.4-style

### DIFF
--- a/tests/KdybyTests/Translation/extractor-files/HomepagePresenter.php
+++ b/tests/KdybyTests/Translation/extractor-files/HomepagePresenter.php
@@ -47,22 +47,14 @@ class HomepagePresenter extends Nette\Application\UI\Presenter
 				->addRule($form::FILLED, "The image is missing!", 4);
 
 		$form->addSubmit("send", "Submit");
-		$form->onSuccess[] = $this->saveSucceeded;
+		$form->onSuccess[] = function (Form $form, $values) {
+			$this->flashMessage("Entry with id %id% was saved", 'warning')
+				->parameters = ['id' => $this->getParameter('id')];
+
+			$this->redirect('list');
+		};
 
 		return $form;
-	}
-
-
-
-	/**
-	 * @param Form $form
-	 */
-	public function saveSucceeded(Form $form)
-	{
-		$this->flashMessage("Entry with id %id% was saved", 'warning')
-			->parameters = ['id' => $this->getParameter('id')];
-
-		$this->redirect('list');
 	}
 
 }


### PR DESCRIPTION
This file doesn't seem to be used at all, but if it would be, this is how `onSuccess` should be defined in Nette 2.4

Maybe the file should even be removed instead.
