### PR TITLE
Support array loader

### DIFF
--- a/src/DI/config/loaders.neon
+++ b/src/DI/config/loaders.neon
@@ -1,3 +1,4 @@
+array: Symfony\Component\Translation\Loader\ArrayLoader
 php: Symfony\Component\Translation\Loader\PhpFileLoader
 yml: Symfony\Component\Translation\Loader\YamlFileLoader
 xlf: Symfony\Component\Translation\Loader\XliffFileLoader

--- a/src/Diagnostics/Panel.php
+++ b/src/Diagnostics/Panel.php
@@ -244,6 +244,10 @@ class Panel implements \Tracy\IBarPanel
 	 */
 	public function addResource($format, $resource, $locale, $domain)
 	{
+		if (is_array($resource)) {
+			$resource = 'array ' . md5(serialize($resource));
+		}
+
 		$this->resources[$locale][$resource] = $domain;
 	}
 
@@ -260,6 +264,10 @@ class Panel implements \Tracy\IBarPanel
 	 */
 	public function addIgnoredResource($format, $resource, $locale, $domain)
 	{
+		if (is_array($resource)) {
+			$resource = 'array ' . md5(serialize($resource));
+		}
+
 		$this->ignoredResources[$locale][$resource] = $domain;
 	}
 


### PR DESCRIPTION
Symfony allows loading a translation resource from a PHP array using `Symfony\Component\Translation\Loader\ArrayLoader` but Kdyby\Translation does not recognize that loader.

This patch adds the loader to the list of loader. Additionally, because the resource value is used as an array key in the Tracy panel, the value had to be serialized.