### PR TITLE
Namespacing of resources domain

### DIFF
--- a/src/DI/TranslationExtension.php
+++ b/src/DI/TranslationExtension.php
@@ -386,14 +386,14 @@ class TranslationExtension extends \Nette\DI\CompilerExtension
 				}
 
 				$relativePath = str_replace($dir, '', $file->getPath());
-				if($relativePath !== '') {
+				if ($relativePath !== '') {
 					$foldersDomain = str_replace(DIRECTORY_SEPARATOR, '.', $relativePath);
 					$foldersDomain = ltrim($foldersDomain, '.');
-					$m['domain'] = "$foldersDomain.{$m['domain']}";
+					$m['domain'] = $foldersDomain . '.' . $m['domain'];
 				}
 
 				if (is_string($baseDomain)) {
-					$m['domain'] = "$baseDomain.{$m['domain']}";
+					$m['domain'] = $baseDomain . '.' . $m['domain'];
 				}
 
 				if ($whitelistRegexp && !preg_match($whitelistRegexp, $m['locale']) && $builder->parameters['productionMode']) {

--- a/src/DI/TranslationExtension.php
+++ b/src/DI/TranslationExtension.php
@@ -379,32 +379,32 @@ class TranslationExtension extends \Nette\DI\CompilerExtension
 		}, array_keys($this->loaders));
 
 		foreach ($dirs as $baseDomain => $dir) {
-                        foreach (Finder::findFiles($mask)->from($dir) as $file) {
-                                /* @var $file \SplFileInfo */
-                                if (!preg_match('~^(?P<domain>.*?)\.(?P<locale>[^\.]+)\.(?P<format>[^\.]+)$~', $file->getFilename(), $m)) {
-                                        continue;
-                                }
+			foreach (Finder::findFiles($mask)->from($dir) as $file) {
+				/** @var \SplFileInfo $file */
+				if (!preg_match('~^(?P<domain>.*?)\.(?P<locale>[^\.]+)\.(?P<format>[^\.]+)$~', $file->getFilename(), $m)) {
+					continue;
+				}
 
-                                $relativePath = str_replace($dir, '', $file->getPath());
-                                if($relativePath !== '') {
-                                    $foldersDomain = str_replace(DIRECTORY_SEPARATOR, '.', $relativePath);
-                                    $foldersDomain = ltrim($foldersDomain, '.');
-                                    $m['domain'] = "$foldersDomain.{$m['domain']}";
-                                }
+				$relativePath = str_replace($dir, '', $file->getPath());
+				if($relativePath !== '') {
+					$foldersDomain = str_replace(DIRECTORY_SEPARATOR, '.', $relativePath);
+					$foldersDomain = ltrim($foldersDomain, '.');
+					$m['domain'] = "$foldersDomain.{$m['domain']}";
+				}
 
-                                if (is_string($baseDomain)) {
-                                    $m['domain'] = "$baseDomain.{$m['domain']}";
-                                }
+				if (is_string($baseDomain)) {
+					$m['domain'] = "$baseDomain.{$m['domain']}";
+				}
 
-                                if ($whitelistRegexp && !preg_match($whitelistRegexp, $m['locale']) && $builder->parameters['productionMode']) {
-                                        continue; // ignore in production mode, there is no need to pass the ignored resources
-                                }
+				if ($whitelistRegexp && !preg_match($whitelistRegexp, $m['locale']) && $builder->parameters['productionMode']) {
+					continue; // ignore in production mode, there is no need to pass the ignored resources
+				}
 
-                                $this->validateResource($m['format'], $file->getPathname(), $m['locale'], $m['domain']);
-                                $translator->addSetup('addResource', [$m['format'], $file->getPathname(), $m['locale'], $m['domain']]);
-                                $builder->addDependency($file->getPathname());
-                        }
-                }
+				$this->validateResource($m['format'], $file->getPathname(), $m['locale'], $m['domain']);
+				$translator->addSetup('addResource', [$m['format'], $file->getPathname(), $m['locale'], $m['domain']]);
+				$builder->addDependency($file->getPathname());
+			}
+		}
 	}
 
 	/**

--- a/src/PrefixedTranslator.php
+++ b/src/PrefixedTranslator.php
@@ -63,7 +63,6 @@ class PrefixedTranslator implements \Kdyby\Translation\ITranslator
 	public function translate($message, $count = NULL, $parameters = [], $domain = NULL, $locale = NULL)
 	{
 		$translationString = ($message instanceof Phrase ? $message->message : $message);
-		$prefix = $this->prefix . '.';
 
 		if (Strings::startsWith($message, '//')) {
 			$prefix = NULL;
@@ -71,7 +70,13 @@ class PrefixedTranslator implements \Kdyby\Translation\ITranslator
 		}
 
 		if ($message instanceof Phrase) {
-			return $this->translator->translate(new Phrase($prefix . $translationString, $message->count, $message->parameters, $message->domain, $message->locale));
+			if ($domain) {
+				$domain = $this->prefix . '.' . $message->domain;
+			} else {
+				$domain = $this->prefix;
+			}
+
+			return $this->translator->translate(new Phrase($translationString, $message->count, $message->parameters, $domain, $message->locale));
 		}
 
 		if (is_array($count)) {
@@ -81,7 +86,13 @@ class PrefixedTranslator implements \Kdyby\Translation\ITranslator
 			$count = NULL;
 		}
 
-		return $this->translator->translate($prefix . $translationString, $count, (array) $parameters, $domain, $locale);
+		if ($domain) {
+			$domain = $this->prefix . '.' . $domain;
+		} else {
+			$domain = $this->prefix;
+		}
+                
+		return $this->translator->translate($translationString, $count, (array) $parameters, $domain, $locale);
 	}
 
 	/**


### PR DESCRIPTION
```php
public function getTranslationResources() {
   return ['vendor.package' => '__DIR__ . '/../translations'];
}
```
```
translations
--sub1
----sub2
```

Currently if we have file `translations/sub1/sub2/messages.en_US.neon` domain of this resource is only `messages`. It is very bad for modularity and forces to make filenames like `vendor.package.sub1.sub2.messages.en_US.neon`

With this PR domain is builded from key under which is translations folder provided and from subfolders structure. Domain `messages` becomes `vendor.package.sub1.sub2.messages`

@enumag 
Before this PR is largely unuseful to use keys and subfolders, but it is still BC break. Should we release new version?