### PR TITLE
BC break in Nette/Caching v2.5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"php": "^5.6 || ^7.0",
 		"kdyby/strict-objects": "^1.0",
 		"latte/latte": "^2.4.6@dev",
-		"nette/caching": "^2.5@dev",
+		"nette/caching": ">= 2.5.0 <= 2.5.6",
 		"nette/di": "^2.4.10@dev",
 		"nette/finder": "^2.4.1@dev",
 		"nette/http": "^2.4.7@dev",


### PR DESCRIPTION
**Declaration of Kdyby\Translation\Caching\PhpFileStorage::readData($meta) should be compatible with Nette\Caching\Storages\FileStorage::readData(array $meta)**
