### PR TITLE
Cast integer message id to string

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -148,8 +148,8 @@ class Translator extends \Symfony\Component\Translation\Translator implements \K
 			return $message; // what now?
 		}
 
-		if (!is_string($message)) {
-			throw new \Kdyby\Translation\InvalidArgumentException(sprintf('Message id must be a string, %s was given', gettype($message)));
+		if (!is_string($message) && !is_int($message)) {
+			throw new \Kdyby\Translation\InvalidArgumentException(sprintf('Message id must be a string or integer, %s was given', gettype($message)));
 		}
 
 		if (Strings::startsWith($message, '//')) {
@@ -182,8 +182,8 @@ class Translator extends \Symfony\Component\Translation\Translator implements \K
 	 */
 	public function trans($message, array $parameters = [], $domain = NULL, $locale = NULL)
 	{
-		if (!is_string($message)) {
-			throw new \Kdyby\Translation\InvalidArgumentException(sprintf('Message id must be a string, %s was given', gettype($message)));
+		if (!is_string($message) && !is_int($message)) {
+			throw new \Kdyby\Translation\InvalidArgumentException(sprintf('Message id must be a string or integer, %s was given', gettype($message)));
 		}
 
 		if ($domain === NULL) {
@@ -207,8 +207,8 @@ class Translator extends \Symfony\Component\Translation\Translator implements \K
 	 */
 	public function transChoice($message, $number, array $parameters = [], $domain = NULL, $locale = NULL)
 	{
-		if (!is_string($message)) {
-			throw new \Kdyby\Translation\InvalidArgumentException(sprintf('Message id must be a string, %s was given', gettype($message)));
+		if (!is_string($message) && !is_int($message)) {
+			throw new \Kdyby\Translation\InvalidArgumentException(sprintf('Message id must be a string or integer, %s was given', gettype($message)));
 		}
 
 		if ($domain === NULL) {

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -146,10 +146,12 @@ class Translator extends \Symfony\Component\Translation\Translator implements \K
 		} elseif ($message instanceof NetteHtmlString || $message instanceof LatteHtmlString) {
 			$this->logMissingTranslation($message->__toString(), $domain, $locale);
 			return $message; // what now?
+		} elseif (is_int($message)) {
+			$message = (string) $message;
 		}
 
-		if (!is_string($message) && !is_int($message)) {
-			throw new \Kdyby\Translation\InvalidArgumentException(sprintf('Message id must be a string or integer, %s was given', gettype($message)));
+		if (!is_string($message)) {
+			throw new \Kdyby\Translation\InvalidArgumentException(sprintf('Message id must be a string, %s was given', gettype($message)));
 		}
 
 		if (Strings::startsWith($message, '//')) {
@@ -182,8 +184,12 @@ class Translator extends \Symfony\Component\Translation\Translator implements \K
 	 */
 	public function trans($message, array $parameters = [], $domain = NULL, $locale = NULL)
 	{
-		if (!is_string($message) && !is_int($message)) {
-			throw new \Kdyby\Translation\InvalidArgumentException(sprintf('Message id must be a string or integer, %s was given', gettype($message)));
+		if (is_int($message)) {
+			$message = (string) $message;
+		}
+
+		if (!is_string($message)) {
+			throw new \Kdyby\Translation\InvalidArgumentException(sprintf('Message id must be a string, %s was given', gettype($message)));
 		}
 
 		if ($domain === NULL) {
@@ -207,8 +213,12 @@ class Translator extends \Symfony\Component\Translation\Translator implements \K
 	 */
 	public function transChoice($message, $number, array $parameters = [], $domain = NULL, $locale = NULL)
 	{
-		if (!is_string($message) && !is_int($message)) {
-			throw new \Kdyby\Translation\InvalidArgumentException(sprintf('Message id must be a string or integer, %s was given', gettype($message)));
+		if (is_int($message)) {
+			$message = (string) $message;
+		}
+
+		if (!is_string($message)) {
+			throw new \Kdyby\Translation\InvalidArgumentException(sprintf('Message id must be a string, %s was given', gettype($message)));
 		}
 
 		if ($domain === NULL) {


### PR DESCRIPTION
Fix for error when using "Two dimensional" select:
```
$form = new Nette\Application\UI\Form();
$items = [
    '2017' => [
        '1',
        '2',
    ],
    '2018' => [
        '1',
        '2',
    ],
];
$form->addSelect('test', 'Test', $items);
```

Error was: "Message id must be a string, integer was given". As you can see, I was trying to use strings as keys for $items array, but PHP uses integer for key always if it is made up of only digits :(