### PR TITLE
*fix - User Deprecated - Passing "null" as the $locale argument to Sy…

### DIFF
--- a/src/DI/TranslationExtension.php
+++ b/src/DI/TranslationExtension.php
@@ -127,7 +127,7 @@ class TranslationExtension extends \Nette\DI\CompilerExtension
 		$config['cache'] = new Statement($config['cache'], [dirname(Helpers::expand('%tempDir%/cache', $builder->parameters))]);
 
 		$translator = $builder->addDefinition($this->prefix('default'))
-			->setFactory(KdybyTranslator::class, [$this->prefix('@userLocaleResolver')])
+			->setFactory(KdybyTranslator::class, [$this->prefix('@userLocaleResolver'), $config['default']])
 			->addSetup('?->setTranslator(?)', [$this->prefix('@userLocaleResolver.param'), '@self'])
 			->addSetup('setDefaultLocale', [$config['default']])
 			->addSetup('setLocaleWhitelist', [$config['whitelist']]);

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -76,6 +76,7 @@ class Translator extends \Symfony\Component\Translation\Translator implements \K
 
 	/**
 	 * @param \Kdyby\Translation\IUserLocaleResolver $localeResolver
+	 * @param string $locale
 	 * @param \Symfony\Component\Translation\Formatter\MessageFormatterInterface $formatter
 	 * @param \Kdyby\Translation\CatalogueCompiler $catalogueCompiler
 	 * @param \Kdyby\Translation\FallbackResolver $fallbackResolver
@@ -84,6 +85,7 @@ class Translator extends \Symfony\Component\Translation\Translator implements \K
 	 */
 	public function __construct(
 		IUserLocaleResolver $localeResolver,
+		string $locale,
 		MessageFormatterInterface $formatter,
 		CatalogueCompiler $catalogueCompiler,
 		FallbackResolver $fallbackResolver,
@@ -96,8 +98,7 @@ class Translator extends \Symfony\Component\Translation\Translator implements \K
 		$this->fallbackResolver = $fallbackResolver;
 		$this->translationsLoader = $loader;
 
-		parent::__construct('', $formatter);
-		$this->setLocale(NULL);
+		parent::__construct($locale, $formatter);
 	}
 
 	/**


### PR DESCRIPTION
…mfony\Component\Translation\Translator::setLocale() is deprecated since Symfony 4.4

*issue - https://github.com/Kdyby/Translation/issues/173