### PR TITLE
Fixed setting default locale to symfony

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ matrix:
   exclude:
     - php: 7.3
       env: COMPOSER_EXTRA_ARGS="--prefer-stable"
+    - php: 7.4
+      env: COMPOSER_EXTRA_ARGS="--prefer-lowest --prefer-stable"
   allow_failures:
     - env: DEV=1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ php:
   - 7.4
 
 env:
-  - TRAVIS_ALLOW_FAILURE=true
+  - DEV=1
   - COMPOSER_EXTRA_ARGS="--prefer-stable"
   - COMPOSER_EXTRA_ARGS="--prefer-lowest --prefer-stable"
 
@@ -29,6 +29,8 @@ matrix:
   exclude:
     - php: 7.3
       env: COMPOSER_EXTRA_ARGS="--prefer-stable"
+  allow_failures:
+    - env: DEV=1
 
 install:
   - if [ "$CODING_STANDARD" = "1" ]; then composer require --dev --no-update kdyby/coding-standard:^1.0@dev; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ php:
   - 7.4
 
 env:
-  - # dev
+  - TRAVIS_ALLOW_FAILURE=true
   - COMPOSER_EXTRA_ARGS="--prefer-stable"
   - COMPOSER_EXTRA_ARGS="--prefer-lowest --prefer-stable"
 
@@ -29,10 +29,6 @@ matrix:
   exclude:
     - php: 7.3
       env: COMPOSER_EXTRA_ARGS="--prefer-stable"
-  allow_failures:
-    - php: 7.1
-      env: # dev
-    - env:
 
 install:
   - if [ "$CODING_STANDARD" = "1" ]; then composer require --dev --no-update kdyby/coding-standard:^1.0@dev; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 env:
   - # dev
@@ -29,6 +30,8 @@ matrix:
     - php: 7.3
       env: COMPOSER_EXTRA_ARGS="--prefer-stable"
   allow_failures:
+    - php: 7.1
+      env: # dev
     - env:
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
 		"nette/application": "^3.0",
 		"nette/bootstrap": "^3.0",
 		"nette/forms": "^3.0",
-		"tracy/tracy": "^3.0",
+		"tracy/tracy": "^2.7 || ^3.0",
 		"kdyby/console": "^2.7.1@dev",
 		"kdyby/monolog": "^2.0",
 		"symfony/yaml": "^3.4 || ^4.0",

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
 		"kdyby/monolog": "^2.0",
 		"symfony/yaml": "^3.4 || ^4.0",
 		"symfony/console": "^3.4 || ^4.0",
-		"nette/tester": "^2.2",
+		"nette/tester": "^2.3",
 		"mockery/mockery": "^1.0"
 	},
 	"minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
 		"kdyby/monolog": "^2.0",
 		"symfony/yaml": "^3.4 || ^4.0",
 		"symfony/console": "^3.4 || ^4.0",
-		"nette/tester": "^2.3.1",
+		"nette/tester": "^2.2",
 		"mockery/mockery": "^1.0"
 	},
 	"minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
 		"nette/forms": "^3.0",
 		"tracy/tracy": "^3.0",
 		"kdyby/console": "^2.7.1@dev",
-		"kdyby/monolog": "^1.4 || ^2.0",
+		"kdyby/monolog": "^2.0",
 		"symfony/yaml": "^3.4 || ^4.0",
 		"symfony/console": "^3.4 || ^4.0",
 		"nette/tester": "^2.2",

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
 		"kdyby/monolog": "^2.0",
 		"symfony/yaml": "^3.4 || ^4.0",
 		"symfony/console": "^3.4 || ^4.0",
-		"nette/tester": "^2.3",
+		"nette/tester": "^2.3.1",
 		"mockery/mockery": "^1.0"
 	},
 	"minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
 		"nette/forms": "^3.0",
 		"tracy/tracy": "^3.0",
 		"kdyby/console": "^2.7.1@dev",
-		"kdyby/monolog": "^2.0",
+		"kdyby/monolog": "^1.4 || ^2.0",
 		"symfony/yaml": "^3.4 || ^4.0",
 		"symfony/console": "^3.4 || ^4.0",
 		"nette/tester": "^2.2",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,8 +1,6 @@
 parameters:
 	ignoreErrors:
 		- '#Constant TEMP_DIR not found#'
-		# Temporary, untill the resolvers are refactored to work on application request basis
-		- '#Strict comparison using === between string and null will always evaluate to false#'
 		# Optional arguments
 		- "#Casting to string something that's already string#"
 		- "#Casting to int something that's already int#"

--- a/src/LocaleResolver/LocaleParamResolver.php
+++ b/src/LocaleResolver/LocaleParamResolver.php
@@ -51,6 +51,7 @@ class LocaleParamResolver implements \Kdyby\Translation\IUserLocaleResolver
 			return;
 		}
 
+		$this->translator->setLocale('');
 		$this->translator->getLocale(); // invoke resolver
 	}
 

--- a/src/LocaleResolver/LocaleParamResolver.php
+++ b/src/LocaleResolver/LocaleParamResolver.php
@@ -51,7 +51,6 @@ class LocaleParamResolver implements \Kdyby\Translation\IUserLocaleResolver
 			return;
 		}
 
-		$this->translator->setLocale(NULL);
 		$this->translator->getLocale(); // invoke resolver
 	}
 

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -97,7 +97,6 @@ class Translator extends \Symfony\Component\Translation\Translator implements \K
 		$this->translationsLoader = $loader;
 
 		parent::__construct('', $formatter);
-		$this->setLocale(NULL);
 	}
 
 	/**
@@ -349,7 +348,7 @@ class Translator extends \Symfony\Component\Translation\Translator implements \K
 	 */
 	public function getLocale()
 	{
-		if (parent::getLocale() === NULL) {
+		if (empty(parent::getLocale())) {
 			$this->setLocale($this->localeResolver->resolve($this));
 		}
 

--- a/tests/KdybyTests/Translation/TemplateHelpersTest.phpt
+++ b/tests/KdybyTests/Translation/TemplateHelpersTest.phpt
@@ -39,12 +39,12 @@ class TemplateHelpersTest extends \KdybyTests\Translation\TestCase
 		Assert::same('front.missingKey.namedHelloCounting', $helper->translate('front.missingKey.namedHelloCounting', ['name' => 'Peter'], NULL, 'en'));
 	}
 
-    public function testGetTranslator()
-    {
-        $translator = $this->createTranslator();
-        $helper = new TemplateHelpers($translator);
+	public function testGetTranslator()
+	{
+		$translator = $this->createTranslator();
+		$helper = new TemplateHelpers($translator);
 
-        Assert::true($helper->getTranslator() instanceof ITranslator);
+		Assert::true($helper->getTranslator() instanceof ITranslator);
 	}
 
 }

--- a/tests/KdybyTests/Translation/TemplateHelpersTest.phpt
+++ b/tests/KdybyTests/Translation/TemplateHelpersTest.phpt
@@ -8,6 +8,7 @@
 
 namespace KdybyTests\Translation;
 
+use Kdyby\Translation\ITranslator;
 use Kdyby\Translation\TemplateHelpers;
 use Tester\Assert;
 
@@ -36,6 +37,14 @@ class TemplateHelpersTest extends \KdybyTests\Translation\TestCase
 		Assert::same('front.missingKey.namedHelloCounting', $helper->translate('front.missingKey.namedHelloCounting', 3, NULL, NULL, 'en'));
 		Assert::same('front.missingKey.namedHelloCounting', $helper->translate('front.missingKey.namedHelloCounting', 3, ['name' => 'Peter'], NULL, 'en'));
 		Assert::same('front.missingKey.namedHelloCounting', $helper->translate('front.missingKey.namedHelloCounting', ['name' => 'Peter'], NULL, 'en'));
+	}
+
+    public function testGetTranslator()
+    {
+        $translator = $this->createTranslator();
+        $helper = new TemplateHelpers($translator);
+
+        Assert::true($helper->getTranslator() instanceof ITranslator);
 	}
 
 }


### PR DESCRIPTION
The newest symfony/translation version (4.4.14) changes the default locale setting in Translator::setLocale - if the $locale value is null, the default system locale is used. This causes the if statement in Kdyby Translator::getLocale to evaluate to false, so the default locale is never used.