### PR TITLE
Extension: Rewrite deprecated Nette Callback::closure() to native \Closure::fromCallable().

### DIFF
--- a/src/DI/TranslationExtension.php
+++ b/src/DI/TranslationExtension.php
@@ -40,7 +40,6 @@ use Nette\PhpGenerator\PhpLiteral;
 use Nette\Reflection\ClassType as ReflectionClassType;
 use Nette\Schema\Expect;
 use Nette\Schema\Schema;
-use Nette\Utils\Callback;
 use Nette\Utils\Finder;
 use Nette\Utils\Validators;
 use Symfony\Component\Translation\Extractor\ChainExtractor;
@@ -372,7 +371,7 @@ class TranslationExtension extends \Nette\DI\CompilerExtension
 			return str_replace((DIRECTORY_SEPARATOR === '/') ? '\\' : '/', DIRECTORY_SEPARATOR, Helpers::expand($dir, $builder->parameters));
 		}, $config['dirs']);
 
-		$dirs = array_values(array_filter($config['dirs'], Callback::closure('is_dir')));
+		$dirs = array_values(array_filter($config['dirs'], \Closure::fromCallable('is_dir')));
 		if (count($dirs) > 0) {
 			foreach ($dirs as $dir) {
 				$builder->addDependency($dir);


### PR DESCRIPTION
Fix BC break.