### PR TITLE
Fix translation of messages with dot at the end

### DIFF
--- a/src/DI/TranslationExtension.php
+++ b/src/DI/TranslationExtension.php
@@ -10,6 +10,7 @@
 
 namespace Kdyby\Translation\DI;
 
+use Closure;
 use Kdyby\Console\DI\ConsoleExtension;
 use Kdyby\Monolog\Logger as KdybyLogger;
 use Kdyby\Translation\Caching\PhpFileStorage;
@@ -40,7 +41,6 @@ use Nette\PhpGenerator\PhpLiteral;
 use Nette\Reflection\ClassType as ReflectionClassType;
 use Nette\Schema\Expect;
 use Nette\Schema\Schema;
-use Nette\Utils\Callback;
 use Nette\Utils\Finder;
 use Nette\Utils\Validators;
 use Symfony\Component\Translation\Extractor\ChainExtractor;
@@ -372,7 +372,7 @@ class TranslationExtension extends \Nette\DI\CompilerExtension
 			return str_replace((DIRECTORY_SEPARATOR === '/') ? '\\' : '/', DIRECTORY_SEPARATOR, Helpers::expand($dir, $builder->parameters));
 		}, $config['dirs']);
 
-		$dirs = array_values(array_filter($config['dirs'], Callback::closure('is_dir')));
+		$dirs = array_values(array_filter($config['dirs'], Closure::fromCallable('is_dir')));
 		if (count($dirs) > 0) {
 			foreach ($dirs as $dir) {
 				$builder->addDependency($dir);

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -201,9 +201,9 @@ class Translator extends \Symfony\Component\Translation\Translator implements \K
 		}
 
 		if ($id === '') {
-		    $id = $message;
-		    $domain = NULL;
-        }
+			$id = $message;
+			$domain = NULL;
+		}
 
 		$result = parent::trans($id, $parameters, $domain, $locale);
 		if ($result === "\x01") {
@@ -234,10 +234,10 @@ class Translator extends \Symfony\Component\Translation\Translator implements \K
 			$id = $message;
 		}
 
-        if ($id === '') {
-            $id = $message;
-            $domain = NULL;
-        }
+		if ($id === '') {
+			$id = $message;
+			$domain = NULL;
+		}
 
 		try {
 			$result = parent::transChoice($id, $number, $parameters, $domain, $locale);

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -200,6 +200,11 @@ class Translator extends \Symfony\Component\Translation\Translator implements \K
 			$id = $message;
 		}
 
+		if ($id === '') {
+		    $id = $message;
+		    $domain = NULL;
+        }
+
 		$result = parent::trans($id, $parameters, $domain, $locale);
 		if ($result === "\x01") {
 			$this->logMissingTranslation($message, $domain, $locale);
@@ -228,6 +233,11 @@ class Translator extends \Symfony\Component\Translation\Translator implements \K
 		} else {
 			$id = $message;
 		}
+
+        if ($id === '') {
+            $id = $message;
+            $domain = NULL;
+        }
 
 		try {
 			$result = parent::transChoice($id, $number, $parameters, $domain, $locale);

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -200,11 +200,6 @@ class Translator extends \Symfony\Component\Translation\Translator implements \K
 			$id = $message;
 		}
 
-		if ($id === '') {
-			$id = $message;
-			$domain = NULL;
-		}
-
 		$result = parent::trans($id, $parameters, $domain, $locale);
 		if ($result === "\x01") {
 			$this->logMissingTranslation($message, $domain, $locale);
@@ -232,11 +227,6 @@ class Translator extends \Symfony\Component\Translation\Translator implements \K
 
 		} else {
 			$id = $message;
-		}
-
-		if ($id === '') {
-			$id = $message;
-			$domain = NULL;
 		}
 
 		try {
@@ -445,7 +435,7 @@ class Translator extends \Symfony\Component\Translation\Translator implements \K
 	 */
 	private function extractMessageDomain($message)
 	{
-		if (strpos($message, '.') !== FALSE && strpos($message, ' ') === FALSE) {
+		if (strpos($message, '.') !== FALSE && strpos(strrev($message), '.') !== 0 && strpos($message, ' ') === FALSE) {
 			list($domain, $message) = explode('.', $message, 2);
 
 		} else {

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -435,7 +435,7 @@ class Translator extends \Symfony\Component\Translation\Translator implements \K
 	 */
 	private function extractMessageDomain($message)
 	{
-		if (strpos($message, '.') !== FALSE && strpos(strrev($message), '.') !== 0 && strpos($message, ' ') === FALSE) {
+		if (strpos(substr($message, 0, -1), '.') !== FALSE && strpos($message, ' ') === FALSE) {
 			list($domain, $message) = explode('.', $message, 2);
 
 		} else {

--- a/tests/KdybyTests/Translation/TranslatorTest.phpt
+++ b/tests/KdybyTests/Translation/TranslatorTest.phpt
@@ -161,8 +161,8 @@ class TranslatorTest extends \KdybyTests\Translation\TestCase
 	{
 		$translator = $this->createTranslator();
 
-		Assert::same('Hello.', $translator->translate('Hello.']));
-		Assert::same('Hello world.', $translator->translate('Hello world.']));
+		Assert::same('Hello.', $translator->translate('Hello.'));
+		Assert::same('Hello world.', $translator->translate('Hello world.'));
 	}
 }
 

--- a/tests/KdybyTests/Translation/TranslatorTest.phpt
+++ b/tests/KdybyTests/Translation/TranslatorTest.phpt
@@ -163,6 +163,7 @@ class TranslatorTest extends \KdybyTests\Translation\TestCase
 		Assert::same('Hello.', $translator->translate('Hello.'));
 		Assert::same('Hello world.', $translator->translate('Hello world.'));
 	}
+
 }
 
 (new TranslatorTest())->run();

--- a/tests/KdybyTests/Translation/TranslatorTest.phpt
+++ b/tests/KdybyTests/Translation/TranslatorTest.phpt
@@ -160,7 +160,6 @@ class TranslatorTest extends \KdybyTests\Translation\TestCase
 	public function testBugMessageWithDotAtTheEnd()
 	{
 		$translator = $this->createTranslator();
-
 		Assert::same('Hello.', $translator->translate('Hello.'));
 		Assert::same('Hello world.', $translator->translate('Hello world.'));
 	}

--- a/tests/KdybyTests/Translation/TranslatorTest.phpt
+++ b/tests/KdybyTests/Translation/TranslatorTest.phpt
@@ -157,11 +157,11 @@ class TranslatorTest extends \KdybyTests\Translation\TestCase
 		Assert::same('Hello world', $translator->translate('Hello %value%', ['value' => 'world']));
 	}
 
-    public function testBugMessageWithDotAtTheEnd()
+	public function testBugMessageWithDotAtTheEnd()
 	{
 		$translator = $this->createTranslator();
 
-        Assert::same('Hello.', $translator->translate('Hello.']));
+		Assert::same('Hello.', $translator->translate('Hello.']));
 		Assert::same('Hello world.', $translator->translate('Hello world.']));
 	}
 }

--- a/tests/KdybyTests/Translation/TranslatorTest.phpt
+++ b/tests/KdybyTests/Translation/TranslatorTest.phpt
@@ -157,6 +157,13 @@ class TranslatorTest extends \KdybyTests\Translation\TestCase
 		Assert::same('Hello world', $translator->translate('Hello %value%', ['value' => 'world']));
 	}
 
+    public function testBugMessageWithDotAtTheEnd()
+	{
+		$translator = $this->createTranslator();
+
+        Assert::same('Hello.', $translator->translate('Hello.']));
+		Assert::same('Hello world.', $translator->translate('Hello world.']));
+	}
 }
 
 (new TranslatorTest())->run();


### PR DESCRIPTION
If you have some strings like:

Hello.
Hello world.

(with dot at the end), whole message is marked as domain, and id is empty, which leads to translation these messages as empty strings.