### PR TITLE
Fix compatibility with Nette/Caching v3.1.3

### DIFF
--- a/src/Caching/PhpFileStorage.php
+++ b/src/Caching/PhpFileStorage.php
@@ -29,6 +29,8 @@ class PhpFileStorage extends \Nette\Caching\Storages\FileStorage implements \Net
 	private const FILE = 'file';
 	private const HANDLE = 'handle';
 
+	private const NS_SEPARATOR = "\x00";
+
 	/**
 	 * Reads cache data from disk.
 	 *
@@ -54,7 +56,7 @@ class PhpFileStorage extends \Nette\Caching\Storages\FileStorage implements \Net
 		$cacheKey = substr_replace(
 			$key,
 			trim(strtr($this->hint, '\\/@', '.._'), '.') . '-',
-			strpos($key, Cache::NAMESPACE_SEPARATOR) + 1,
+			strpos($key, self::NS_SEPARATOR) + 1,
 			0
 		);
 


### PR DESCRIPTION
- at last version of Nette/Caching https://github.com/nette/caching/releases/tag/v3.1.3 was changed name of constant `NAMESPACE_SEPARATOR` to `NamespaceSeparator`
- because constant is **internal**, i moved it to project