### PR TITLE
Do not merge default fallbacks

### DIFF
--- a/src/DI/TranslationExtension.php
+++ b/src/DI/TranslationExtension.php
@@ -105,7 +105,7 @@ class TranslationExtension extends \Nette\DI\CompilerExtension
 			'whitelist' => Expect::anyOf(Expect::arrayOf('string'), NULL),
 			'default' => Expect::string('en'),
 			'logging' => Expect::anyOf(Expect::string(), Expect::bool()),
-			'fallback' => Expect::arrayOf('string')->default(['en_US']),
+			'fallback' => Expect::arrayOf('string')->default(['en_US'])->mergeDefaults(false),
 			'dirs' => Expect::arrayOf('string')->default(['%appDir%/lang', '%appDir%/locale']),
 			'cache' => Expect::string(PhpFileStorage::class),
 			'debugger' => Expect::bool(FALSE),


### PR DESCRIPTION
If some fallbacks are set in config, they are placed AFTER default value, so first fallback is always en_US.
This change removes this behavior.